### PR TITLE
Using a singularity container is implicit consent

### DIFF
--- a/R/consent.R
+++ b/R/consent.R
@@ -79,6 +79,7 @@ renv_consent_check <- function() {
     !is.na(Sys.getenv("CI", unset = NA)) ||
     !is.na(Sys.getenv("GITHUB_ACTION", unset = NA)) ||
     !is.na(Sys.getenv("RENV_PATHS_ROOT", unset = NA)) ||
+    dir.exists("/.singularity.d") ||
     file.exists("/.dockerenv")
 
   if (consented)


### PR DESCRIPTION
In similarity to using a docker container, this pull request adds a test for the `/.singularity.d` directory in a singularity container, to provide implicit consent.

Thanks for considering this.